### PR TITLE
Added Pins to Boards, delete feature. 

### DIFF
--- a/json_sample_data/pins.json
+++ b/json_sample_data/pins.json
@@ -2,7 +2,7 @@
   "-MV--ro-YXXQFivU6n5j" : {
     "board_id" : "-MUzyWGx6kur2rATfWCk",
     "firebaseKey" : "-MV--ro-YXXQFivU6n5j",
-    "image" : "blank",
+    "image" : "https://www.lulus.com/images/product/xlarge/2833110_544232.jpg?w=560",
     "pin_description" : "A rockin navy lady blazer",
     "pin_title" : "Blue Blazer",
     "uid" : "0d6GQQ0VHkUUVhd5E5NnEmPZCTB2"
@@ -10,7 +10,7 @@
   "-MV--vxyYwWWYmYQhOyp" : {
     "board_id" : "-MUzyWGx6kur2rATfWCk",
     "firebaseKey" : "-MV--vxyYwWWYmYQhOyp",
-    "image" : "blank",
+    "image" : "https://image.menswearhouse.com/is/image/TMW/MW40_11YT_11_EGARA_RED_SET?$40MainPDP$",
     "pin_description" : "A rockin red blazer",
     "pin_title" : "Red Blazer",
     "uid" : "0d6GQQ0VHkUUVhd5E5NnEmPZCTB2"
@@ -18,7 +18,7 @@
   "-MV--ywccZZpOGKFQuU3" : {
     "board_id" : "-MUzyWGx6kur2rATfWCk",
     "firebaseKey" : "-MV--ywccZZpOGKFQuU3",
-    "image" : "blank",
+    "image" : "https://cdn.shopify.com/s/files/1/0132/2119/9931/products/neil-allyn-kelly-green-mens-uniform-blazer_1346x.jpg?v=1562927368",
     "pin_description" : "A rockin green blazer",
     "pin_title" : "Green Blazer",
     "uid" : "0d6GQQ0VHkUUVhd5E5NnEmPZCTB2"
@@ -26,23 +26,23 @@
   "-MV-0A3naF4XhAUD_Xgw" : {
     "board_id" : "-MUzyh2UZCcZ0yWCZ48a",
     "firebaseKey" : "-MV-0A3naF4XhAUD_Xgw",
-    "image" : "blank",
-    "pin_description" : "A fast car",
-    "pin_title" : "Fast Car",
+    "image" : "https://www.newcartestdrive.com/wp-content/uploads/2020/04/2020_Dodge_Challenger_hero-610x400.jpg",
+    "pin_description" : "A throwback to the 1970 debut of the Dodge Challenger",
+    "pin_title" : "2020 Dodge Challenger",
     "uid" : "0d6GQQ0VHkUUVhd5E5NnEmPZCTB2"
   },
   "-MV-0FG4KDUGZ7ixZkq3" : {
     "board_id" : "-MUzyh2UZCcZ0yWCZ48a",
     "firebaseKey" : "-MV-0FG4KDUGZ7ixZkq3",
-    "image" : "blank",
-    "pin_description" : "A cool car",
-    "pin_title" : "Muscle Car",
+    "image" : "https://i1.wp.com/www.pomonaswapmeet.com/blog/wp-content/uploads/2014/05/dodge-challenger-1970-153.jpg?fit=1280%2C960&ssl=1",
+    "pin_description" : "The inspiration behind the modern Dodge Challenger",
+    "pin_title" : "1970 Dodge Challenger",
     "uid" : "0d6GQQ0VHkUUVhd5E5NnEmPZCTB2"
   },
   "-MV-0MhKF4vc4OEc_ng2" : {
     "board_id" : "-MUzykjjFQRKPoRiiRLP",
     "firebaseKey" : "-MV-0MhKF4vc4OEc_ng2",
-    "image" : "blank",
+    "image" : "https://i.dell.com/is/image/DellContent//content/dam/global-site-design/product_images/dell_client_products/desktops/inspiron_desktops/27_7790/general/new-category-page-desktop-inspiron-27-7790-3880-800x620.png?fmt=png-alpha&amp;wid=800&amp;hei=620",
     "pin_description" : "A desktop computer",
     "pin_title" : "Desktop",
     "uid" : "0d6GQQ0VHkUUVhd5E5NnEmPZCTB2"
@@ -50,9 +50,9 @@
   "-MV-0PdMlH0eIGp_KBPS" : {
     "board_id" : "-MUzykjjFQRKPoRiiRLP",
     "firebaseKey" : "-MV-0PdMlH0eIGp_KBPS",
-    "image" : "blank",
-    "pin_description" : "A laptop computer",
-    "pin_title" : "Laptop",
+    "image" : "http://i.dell.com/sites/csimages/Video_Imagery/all/xps_7590_touch.png",
+    "pin_description" : "The laptop that was used in developing this web app",
+    "pin_title" : "Precision Laptop",
     "uid" : "0d6GQQ0VHkUUVhd5E5NnEmPZCTB2"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet">
   <link rel="shortcut icon" href="#">
   <title>Pin Boards</title>
 </head>

--- a/src/javascripts/components/boards.js
+++ b/src/javascripts/components/boards.js
@@ -6,7 +6,7 @@ const showBoards = (array) => {
     <img src='${item.image}' class="card-img-top" alt="...">
     <div class="card-body">
       <h5 class="card-title">${item.board_title}</h5>
-      <a href="#" class="btn btn-danger">Visit Board</a>
+      <a href="#" class="btn btn-danger" id="viewBoard--${item.firebaseKey}">Visit Board</a>
     </div>
   </div>`;
   });

--- a/src/javascripts/components/domBuilder.js
+++ b/src/javascripts/components/domBuilder.js
@@ -2,7 +2,8 @@ const domBuilder = () => {
   document.querySelector('#app').innerHTML = `
   <div id="navigation"></div>
   <div id="main-container"></div>
-  <div class="d-flex flexwrap justify-content-around" id="boards"></div>`;
+  <div class="d-flex flexwrap justify-content-around" id="boards"></div>
+  <div class="align-text-center mt-3" id="stage"></div>`;
 };
 
 export default domBuilder;

--- a/src/javascripts/components/guestNavbar.js
+++ b/src/javascripts/components/guestNavbar.js
@@ -1,6 +1,6 @@
-import logoutButton from './buttons/logoutButton';
+import loginButton from './buttons/loginButton';
 
-const navbar = () => {
+const guestNavbar = () => {
   const domString = `<nav class="navbar navbar-expand-lg navbar-light bg-light">
   <div class="container-fluid">
     <span class="material-icons">face</span>
@@ -23,7 +23,7 @@ const navbar = () => {
   </div>
 </nav>`;
   document.querySelector('#navigation').innerHTML = domString;
-  logoutButton();
+  loginButton();
 };
 
-export default navbar;
+export default guestNavbar;

--- a/src/javascripts/components/pins.js
+++ b/src/javascripts/components/pins.js
@@ -1,0 +1,18 @@
+const showPins = (array) => {
+  document.querySelector('#main-container').innerHTML = '<h1>Pins</h1>';
+  document.querySelector('#stage').innerHTML = '<a href="#" class="btn btn-danger" id="returnPins">Return to Boards</a></hr>';
+  document.querySelector('#boards').innerHTML = '';
+
+  array.forEach((item) => {
+    document.querySelector('#boards').innerHTML += `<div class="card" style="width: 18rem;">
+    <img src='${item.image}' class="card-img-top" alt="...">
+    <div class="card-body">
+      <h5 class="card-title">${item.pin_title}</h5>
+      <p>${item.pin_description}</p>
+      <a href="#" class="btn btn-danger" id="deletePin^^${item.firebaseKey}^^${item.board_id}">Delete Pin</a>
+    </div>
+  </div>`;
+  });
+};
+
+export default showPins;

--- a/src/javascripts/data/boardData.js
+++ b/src/javascripts/data/boardData.js
@@ -6,9 +6,9 @@ const dbUrl = firebaseConfig.databaseURL;
 
 // GET BOARDS
 
-const getBoards = () => new Promise((resolve, reject) => {
-  axios.get(`${dbUrl}/boards.json`)
-    .then((response) => resolve(Object.values((response.data))))
+const getBoards = (userId) => new Promise((resolve, reject) => {
+  axios.get(`${dbUrl}/boards.json?orderBy="uid"&equalTo="${userId}"`)
+    .then((response) => resolve(Object.values(response.data)))
     .catch((error) => reject(error));
 });
 

--- a/src/javascripts/data/pinData.js
+++ b/src/javascripts/data/pinData.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import firebaseConfig from '../helpers/apiKeys';
+
+// API CALLS FOR BOARDS
+const dbUrl = firebaseConfig.databaseURL;
+
+// GET BOARDS
+
+const getPins = (firebaseKey) => new Promise((resolve, reject) => {
+  axios.get(`${dbUrl}/pins.json?orderBy="board_id"&equalTo="${firebaseKey}"`)
+    .then((response) => resolve(Object.values(response.data)))
+    .catch((error) => reject(error));
+});
+
+// Delete Pins
+
+const deletePin = (firebaseKey, boardId) => new Promise((resolve, reject) => {
+  axios.delete(`${dbUrl}/pins/${firebaseKey}.json`)
+    .then(() => getPins(boardId).then((pins) => resolve(pins)))
+    .catch((error) => reject(error));
+});
+
+export { getPins, deletePin };

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -1,0 +1,34 @@
+import showBoards from '../components/boards';
+import showPins from '../components/pins';
+import getBoards from '../data/boardData';
+import { deletePin, getPins } from '../data/pinData';
+
+const domEvents = (userId) => {
+  document.querySelector('body').addEventListener('click', (e) => {
+    // Event for clicking into pins
+    if (e.target.id.includes('viewBoard')) {
+      e.preventDefault();
+      const firebaseKey = e.target.id.split('--')[1];
+      getPins(firebaseKey).then((pins) => showPins(pins));
+    }
+    // Event to return to main page from pins
+    if (e.target.id.includes('returnPins')) {
+      e.preventDefault();
+      document.querySelector('#boards').innerHTML = '';
+      document.querySelector('#stage').innerHTML = '';
+      getBoards(userId).then((boards) => showBoards(boards));
+    }
+
+    if (e.target.id.includes('deletePin')) {
+      // eslint-disable-next-line no-alert
+      if (window.confirm('Want to Delete?')) {
+        e.preventDefault();
+        const firebaseKey = e.target.id.split('^^')[1];
+        const boardId = e.target.id.split('^^')[2];
+        deletePin(firebaseKey, boardId).then((pins) => showPins(pins));
+      }
+    }
+  });
+};
+
+export default domEvents;

--- a/src/javascripts/helpers/auth.js
+++ b/src/javascripts/helpers/auth.js
@@ -1,7 +1,5 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
-import loginButton from '../components/buttons/loginButton';
-import logoutButton from '../components/buttons/logoutButton';
 import guestApp from '../views/guestApp';
 import startApp from '../views/startApp';
 import firebaseConfig from './apiKeys';
@@ -10,12 +8,10 @@ const checkLoginStatus = () => {
   firebase.initializeApp(firebaseConfig);
   firebase.auth().onAuthStateChanged((user) => {
     if (user) {
-      startApp();
-      logoutButton();
+      startApp(user);
     } else {
       // person is NOT logged in
       guestApp();
-      loginButton();
     }
   });
 };

--- a/src/javascripts/views/guestApp.js
+++ b/src/javascripts/views/guestApp.js
@@ -1,11 +1,10 @@
 import domBuilder from '../components/domBuilder';
+import guestNavbar from '../components/guestNavbar';
 import homePage from '../components/home';
-import navbar from '../components/navbar';
 
 const guestApp = () => {
   domBuilder();
-  navbar();
   homePage();
+  guestNavbar();
 };
-
 export default guestApp;

--- a/src/javascripts/views/startApp.js
+++ b/src/javascripts/views/startApp.js
@@ -1,13 +1,14 @@
-// import showBoards from '../components/boards';
 import showBoards from '../components/boards';
 import domBuilder from '../components/domBuilder';
 import navbar from '../components/navbar';
 import getBoards from '../data/boardData';
+import domEvents from '../events/domEvents';
 
-const startApp = () => {
+const startApp = (user) => {
   domBuilder(); // Building the DOM
   navbar();
-  getBoards().then((boards) => showBoards(boards));
+  getBoards(user.uid).then((boards) => showBoards(boards));
+  domEvents(user.uid);
 };
 
 export default startApp;


### PR DESCRIPTION
Added Components to render Pins on Boards, and delete pins. 

## Description
Users can now click on each board and view each pin associated with that board. There is a button to return to the home page from here. Additionally, users may delete pins by clicking the delete button. 

## Related Issue
fixes #15 #14 #13 #12 #11 #10 #19 #17 

## Motivation and Context
Users can get granular with adding specific pins to each board, and expand their collection. As the collection changes, the user may delete a pin. 

## How Can This Be Tested?
npm -start, click on the board. Pins should render. Hit the delete button to remove a pin (this does remove it from the database). Click return to boards to return home. 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
