### PR TITLE
Delete Boards 

### DIFF
--- a/src/javascripts/components/boards.js
+++ b/src/javascripts/components/boards.js
@@ -1,5 +1,6 @@
 const showBoards = (array) => {
   document.querySelector('#main-container').innerHTML = '<h1>Boards</h1>';
+  document.querySelector('#boards').innerHTML = '';
 
   array.forEach((item) => {
     document.querySelector('#boards').innerHTML += `<div class="card" style="width: 18rem;">
@@ -7,6 +8,7 @@ const showBoards = (array) => {
     <div class="card-body">
       <h5 class="card-title">${item.board_title}</h5>
       <a href="#" class="btn btn-danger" id="viewBoard--${item.firebaseKey}">Visit Board</a>
+      <a href="#" class="btn btn-danger" id="deleteBoard--${item.firebaseKey}">Delete Board</a>
     </div>
   </div>`;
   });

--- a/src/javascripts/data/boardData.js
+++ b/src/javascripts/data/boardData.js
@@ -12,4 +12,10 @@ const getBoards = (userId) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-export default getBoards;
+const deleteBoard = (firebaseKey, userId) => new Promise((resolve, reject) => {
+  axios.delete(`${dbUrl}/boards/${firebaseKey}.json`)
+    .then(() => getBoards(userId).then((boardsArray) => resolve(boardsArray)))
+    .catch((error) => reject(error));
+});
+
+export { getBoards, deleteBoard };

--- a/src/javascripts/data/pinBoardData.js
+++ b/src/javascripts/data/pinBoardData.js
@@ -1,0 +1,12 @@
+import { deleteBoard } from './boardData';
+import { deletePin, getPins } from './pinData';
+
+const deleteBoardPins = (boardId, userId) => new Promise((resolve, reject) => {
+  getPins(boardId).then((pinsArray) => {
+    const deletePins = pinsArray.map((pin) => deletePin(pin.firebaseKey));
+
+    Promise.all(deletePins).then(() => resolve(deleteBoard(boardId, userId)));
+  }).catch((error) => reject(error));
+});
+
+export default deleteBoardPins;

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -1,6 +1,7 @@
 import showBoards from '../components/boards';
 import showPins from '../components/pins';
-import getBoards from '../data/boardData';
+import { getBoards } from '../data/boardData';
+import deleteBoardPins from '../data/pinBoardData';
 import { deletePin, getPins } from '../data/pinData';
 
 const domEvents = (userId) => {
@@ -26,6 +27,15 @@ const domEvents = (userId) => {
         const firebaseKey = e.target.id.split('^^')[1];
         const boardId = e.target.id.split('^^')[2];
         deletePin(firebaseKey, boardId).then((pins) => showPins(pins));
+      }
+    }
+
+    if (e.target.id.includes('deleteBoard')) {
+      // eslint-disable-next-line no-alert
+      if (window.confirm('Want to Delete?')) {
+        e.preventDefault();
+        const firebaseKey = e.target.id.split('--')[1];
+        deleteBoardPins(firebaseKey, userId).then((boardsArray) => showBoards(boardsArray));
       }
     }
   });

--- a/src/javascripts/views/startApp.js
+++ b/src/javascripts/views/startApp.js
@@ -1,7 +1,7 @@
 import showBoards from '../components/boards';
 import domBuilder from '../components/domBuilder';
 import navbar from '../components/navbar';
-import getBoards from '../data/boardData';
+import { getBoards } from '../data/boardData';
 import domEvents from '../events/domEvents';
 
 const startApp = (user) => {


### PR DESCRIPTION
Added delete function for boards and all associated pins

## Description
A user can delete a board, and all associated pins by clicking the 'Delete Board' button. 

## Related Issue
fixes #16 
fixes #18 

## Motivation and Context
A user may want to delete an entire collection within a board, and all associated pins. This will be more efficient than deleting pins individually, and allow for better organization of material as a user's need for boards change over time.

## How Can This Be Tested?
npm start, click the 'Delete Board' button. The board should delete, and all pins along with it. 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
