### PR TITLE
Add create Boards and Pins

### DIFF
--- a/src/javascripts/components/boards.js
+++ b/src/javascripts/components/boards.js
@@ -1,9 +1,11 @@
 const showBoards = (array) => {
   document.querySelector('#main-container').innerHTML = '<h1>Boards</h1>';
+  document.querySelector('#stage').innerHTML = '<a href="#" class="btn btn-danger" id="createBoard">Add a Board</a></hr>';
   document.querySelector('#boards').innerHTML = '';
+  document.querySelector('#form-container').innerHTML = '';
 
   array.forEach((item) => {
-    document.querySelector('#boards').innerHTML += `<div class="card" style="width: 18rem;">
+    document.querySelector('#boards').innerHTML += `<div class="card mt-3" style="width: 18rem;">
     <img src='${item.image}' class="card-img-top" alt="...">
     <div class="card-body">
       <h5 class="card-title">${item.board_title}</h5>

--- a/src/javascripts/components/domBuilder.js
+++ b/src/javascripts/components/domBuilder.js
@@ -2,8 +2,9 @@ const domBuilder = () => {
   document.querySelector('#app').innerHTML = `
   <div id="navigation"></div>
   <div id="main-container"></div>
-  <div class="d-flex flexwrap justify-content-around" id="boards"></div>
-  <div class="align-text-center mt-3" id="stage"></div>`;
+  <div class="d-flex flex-wrap justify-content-around" id="boards"></div>
+  <div class="align-text-center my-3" id="stage"></div>
+  <div id="form-container"></div>`;
 };
 
 export default domBuilder;

--- a/src/javascripts/components/forms/addBoardForm.js
+++ b/src/javascripts/components/forms/addBoardForm.js
@@ -1,0 +1,21 @@
+const addBoardForm = () => {
+  document.querySelector('#boards').innerHTML = '';
+  document.querySelector('#stage').innerHTML = '';
+  document.querySelector('#main-container').innerHTML = '';
+
+  document.querySelector('#form-container').innerHTML = `<form id="submit-pin-form" class="mb-4">
+  <div class="form-group">
+    <label for="board-title">Board Title</label>
+    <input type="text" class="form-control" id="board-title" aria-describedby="bookTitle" placeholder="Enter Board Title" required>
+  </div>
+  <div class="form-group">
+    <label for="board-image">Image URL</label>
+    <input type="url" class="form-control" id="board-image" placeholder="Image URL" required>
+  </div>
+  <div class="form-group" id="select-board">
+  </div>
+  <button type="submit" id="submit-board" class="btn btn-danger">Submit Board</button>
+</form>`;
+};
+
+export default addBoardForm;

--- a/src/javascripts/components/forms/addPinForm.js
+++ b/src/javascripts/components/forms/addPinForm.js
@@ -1,0 +1,29 @@
+import selectBoard from './selectBoard';
+
+const addPinForm = (userId) => {
+  document.querySelector('#boards').innerHTML = '';
+  document.querySelector('#stage').innerHTML = '';
+  document.querySelector('#main-container').innerHTML = '';
+
+  document.querySelector('#form-container').innerHTML = `<form id="submit-pin-form" class="mb-4">
+  <div class="form-group">
+    <label for="title">Pin Title</label>
+    <input type="text" class="form-control" id="title" aria-describedby="bookTitle" placeholder="Enter Pin Title" required>
+  </div>
+  <div class="form-group">
+  <label for="description">Description</label>
+  <input type="text" class="form-control" id="description" placeholder="Pin Description" required>
+  </div>
+  <div class="form-group">
+    <label for="image">Image URL</label>
+    <input type="url" class="form-control" id="image" placeholder="Image URL" required>
+  </div>
+  <div class="form-group" id="select-board">
+  </div>
+  <button type="submit" id="submit-pin" class="btn btn-danger">Submit Pin</button>
+</form>`;
+
+  selectBoard(userId);
+};
+
+export default addPinForm;

--- a/src/javascripts/components/forms/selectBoard.js
+++ b/src/javascripts/components/forms/selectBoard.js
@@ -1,0 +1,18 @@
+import { getBoards } from '../../data/boardData';
+
+const selectBoard = (userId) => {
+  let domString = `<label for="board">Select a Board</label>
+  <select class="form-control" id="board" required>
+  <option value="">Select a Board</option>`;
+
+  getBoards(userId).then((boardsArray) => {
+    boardsArray.forEach((boards) => {
+      domString += `<option value="${boards.firebaseKey}">${boards.board_title}</option>`;
+    });
+    domString += '</select>';
+
+    document.querySelector('#select-board').innerHTML = domString;
+  });
+};
+
+export default selectBoard;

--- a/src/javascripts/components/pins.js
+++ b/src/javascripts/components/pins.js
@@ -1,10 +1,11 @@
 const showPins = (array) => {
   document.querySelector('#main-container').innerHTML = '<h1>Pins</h1>';
-  document.querySelector('#stage').innerHTML = '<a href="#" class="btn btn-danger" id="returnPins">Return to Boards</a></hr>';
+  document.querySelector('#stage').innerHTML = '<a href="#" class="btn btn-danger" id="returnPins">Return to Boards</a> </hr> <a href="#" class="btn btn-danger" id="createPin">Add a Pin</a></hr>';
   document.querySelector('#boards').innerHTML = '';
+  document.querySelector('#form-container').innerHTML = '';
 
   array.forEach((item) => {
-    document.querySelector('#boards').innerHTML += `<div class="card" style="width: 18rem;">
+    document.querySelector('#boards').innerHTML += `<div class="card mt-3" style="width: 18rem;">
     <img src='${item.image}' class="card-img-top" alt="...">
     <div class="card-body">
       <h5 class="card-title">${item.pin_title}</h5>

--- a/src/javascripts/data/boardData.js
+++ b/src/javascripts/data/boardData.js
@@ -12,10 +12,25 @@ const getBoards = (userId) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
+// Delete Board
+
 const deleteBoard = (firebaseKey, userId) => new Promise((resolve, reject) => {
   axios.delete(`${dbUrl}/boards/${firebaseKey}.json`)
     .then(() => getBoards(userId).then((boardsArray) => resolve(boardsArray)))
     .catch((error) => reject(error));
 });
 
-export { getBoards, deleteBoard };
+// Create Board
+
+const createBoard = (boardObj, userId) => new Promise((resolve, reject) => {
+  axios.post(`${dbUrl}/boards.json`, boardObj)
+    .then((response) => {
+      const body = { firebaseKey: response.data.name };
+      axios.patch(`${dbUrl}/boards/${response.data.name}.json`, body)
+        .then(() => {
+          getBoards(userId).then((boardsArray) => resolve(boardsArray));
+        });
+    }).catch((error) => reject(error));
+});
+
+export { getBoards, deleteBoard, createBoard };

--- a/src/javascripts/data/pinData.js
+++ b/src/javascripts/data/pinData.js
@@ -4,7 +4,7 @@ import firebaseConfig from '../helpers/apiKeys';
 // API CALLS FOR BOARDS
 const dbUrl = firebaseConfig.databaseURL;
 
-// GET BOARDS
+// GET Pins
 
 const getPins = (firebaseKey) => new Promise((resolve, reject) => {
   axios.get(`${dbUrl}/pins.json?orderBy="board_id"&equalTo="${firebaseKey}"`)
@@ -20,4 +20,16 @@ const deletePin = (firebaseKey, boardId) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-export { getPins, deletePin };
+// Create Pins
+
+const createPin = (pinObject) => new Promise((resolve, reject) => {
+  axios.post(`${dbUrl}/pins.json`, pinObject)
+    .then((response) => {
+      const body = { firebaseKey: response.data.name };
+      axios.patch(`${dbUrl}/pins/${response.data.name}.json`, body)
+        .then(() => {
+          getPins(pinObject.board_id).then((pinsArray) => resolve(pinsArray));
+        });
+    }).catch((error) => reject(error));
+});
+export { getPins, deletePin, createPin };

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -1,8 +1,10 @@
 import showBoards from '../components/boards';
+import addBoardForm from '../components/forms/addBoardForm';
+import addPinForm from '../components/forms/addPinForm';
 import showPins from '../components/pins';
-import { getBoards } from '../data/boardData';
+import { createBoard, getBoards } from '../data/boardData';
 import deleteBoardPins from '../data/pinBoardData';
-import { deletePin, getPins } from '../data/pinData';
+import { createPin, deletePin, getPins } from '../data/pinData';
 
 const domEvents = (userId) => {
   document.querySelector('body').addEventListener('click', (e) => {
@@ -20,6 +22,7 @@ const domEvents = (userId) => {
       getBoards(userId).then((boards) => showBoards(boards));
     }
 
+    // Delete a Pin
     if (e.target.id.includes('deletePin')) {
       // eslint-disable-next-line no-alert
       if (window.confirm('Want to Delete?')) {
@@ -29,7 +32,7 @@ const domEvents = (userId) => {
         deletePin(firebaseKey, boardId).then((pins) => showPins(pins));
       }
     }
-
+    // Delete a Board
     if (e.target.id.includes('deleteBoard')) {
       // eslint-disable-next-line no-alert
       if (window.confirm('Want to Delete?')) {
@@ -37,6 +40,40 @@ const domEvents = (userId) => {
         const firebaseKey = e.target.id.split('--')[1];
         deleteBoardPins(firebaseKey, userId).then((boardsArray) => showBoards(boardsArray));
       }
+    }
+    // Create pin
+    if (e.target.id.includes('createPin')) {
+      e.preventDefault();
+      addPinForm(userId);
+    }
+    // Submit new pin
+    if (e.target.id.includes('submit-pin')) {
+      console.warn('clicked it');
+      e.preventDefault();
+      const pinObj = {
+        pin_title: document.querySelector('#title').value,
+        pin_description: document.querySelector('#description').value,
+        image: document.querySelector('#image').value,
+        board_id: document.querySelector('#board').value,
+        uid: userId
+      };
+      createPin(pinObj).then((pinArray) => showPins(pinArray));
+    }
+    // Create Board
+    if (e.target.id.includes('createBoard')) {
+      e.preventDefault();
+      addBoardForm();
+    }
+
+    // Submit Board Button
+    if (e.target.id.includes('submit-board')) {
+      e.preventDefault();
+      const boardObj = {
+        board_title: document.querySelector('#board-title').value,
+        image: document.querySelector('#board-image').value,
+        uid: userId,
+      };
+      createBoard(boardObj, userId).then((boardArray) => showBoards(boardArray));
     }
   });
 };

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -8,6 +8,13 @@ body {
   margin-top: 0px;
 }
 
+#form-container {
+  width: 60%;
+  margin: auto;
+  justify-content: center;
+  color: brown;
+}
+
 #boards img {
   display: block;
   height: 175px;


### PR DESCRIPTION
Added buttons to create Boards and Pins, and render onto app. 

## Description
A user can now click on a button to create both a new Board and new Pin. On submission, the new board/pin will upload to the database, and then render to the app screen. 

## Related Issue
fixes #20 
fixes #21 
fixes #22 
fixes #23 

## Motivation and Context
This allows the user to add new boards and pins so that they may customize their boards to fit their needs. 

## How Can This Be Tested?
npm start. On load, click 'Add Board' Type in a Board Name and Image URL. A new board will render to the app. Click 'visit board'. From there, click 'Add Pin'. Type in a Pin Title, Description, and Image URL, and associated board. Submit, and the app will load that pin along with other pins from that same board type. 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
