### PR TITLE
Added Update feature

### DIFF
--- a/src/javascripts/components/domBuilder.js
+++ b/src/javascripts/components/domBuilder.js
@@ -4,7 +4,8 @@ const domBuilder = () => {
   <div id="main-container"></div>
   <div class="d-flex flex-wrap justify-content-around" id="boards"></div>
   <div class="align-text-center my-3" id="stage"></div>
-  <div id="form-container"></div>`;
+  <div id="form-container"></div>
+  <div id="modal-container"></div>`;
 };
 
 export default domBuilder;

--- a/src/javascripts/components/forms/editPinForm.js
+++ b/src/javascripts/components/forms/editPinForm.js
@@ -1,10 +1,11 @@
-// import selectBoard from './selectBoard';
+import selectBoard from './selectBoard';
 
-const editPinForm = () => {
+const editPinForm = (pinObject, userId) => {
   document.querySelector('#modal-body').innerHTML = `<form id="edit-pin-form" class="mb-4">
-  <div class="form-group" id="select-board">Plz work</div>
-  <button type="submit" id="update-pin" class="btn btn-success">Update Pin</button>
+  <div class="form-group" id="select-board"></div>
+  <button type="submit" id="update-pin^^${pinObject.firebaseKey}" class="btn btn-danger">Update Pin</button>
 </form>`;
+  selectBoard(userId);
 };
 
 export default editPinForm;

--- a/src/javascripts/components/forms/editPinForm.js
+++ b/src/javascripts/components/forms/editPinForm.js
@@ -1,0 +1,10 @@
+// import selectBoard from './selectBoard';
+
+const editPinForm = () => {
+  document.querySelector('#modal-body').innerHTML = `<form id="edit-pin-form" class="mb-4">
+  <div class="form-group" id="select-board">Plz work</div>
+  <button type="submit" id="update-pin" class="btn btn-success">Update Pin</button>
+</form>`;
+};
+
+export default editPinForm;

--- a/src/javascripts/components/forms/formModal.js
+++ b/src/javascripts/components/forms/formModal.js
@@ -1,36 +1,19 @@
-const formModal = () => {
-  // document.querySelector('#modal-container').innerHTML = `
-  // <div class="modal fade" id="formModal" tabindex="-1" role="dialog" aria-labelledby="formModalLabel" aria-hidden="true">
-  //   <div class="modal-dialog" role="document">
-  //     <div class="modal-content">
-  //       <div class="modal-header">
-  //         <h5 class="modal-title" id="formModalLabel">${modalTitle}</h5>
-  //         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-  //           <span aria-hidden="true">&times;</span>
-  //         </button>
-  //       </div>
-  //       <div class="modal-body" id="modal-body">
-  //       </div>
-  //     </div>
-  //   </div>
-  // </div>`;
-  document.querySelector('#modal-container').innerHTML = `<div class="modal" tabindex="-1">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Edit Pin</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body" id="modal-body">
-        <p>Modal body text goes here.</p>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Save changes</button>
+const formModal = (modalTitle) => {
+  document.querySelector('#modal-container').innerHTML = `
+  <div class="modal fade" id="formModal" tabindex="-1" role="dialog" aria-labelledby="formModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="formModalLabel">${modalTitle}</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body" id="modal-body">
+        </div>
       </div>
     </div>
-  </div>
-</div>`;
+  </div>`;
 };
 
 export default formModal;

--- a/src/javascripts/components/forms/formModal.js
+++ b/src/javascripts/components/forms/formModal.js
@@ -1,0 +1,36 @@
+const formModal = () => {
+  // document.querySelector('#modal-container').innerHTML = `
+  // <div class="modal fade" id="formModal" tabindex="-1" role="dialog" aria-labelledby="formModalLabel" aria-hidden="true">
+  //   <div class="modal-dialog" role="document">
+  //     <div class="modal-content">
+  //       <div class="modal-header">
+  //         <h5 class="modal-title" id="formModalLabel">${modalTitle}</h5>
+  //         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+  //           <span aria-hidden="true">&times;</span>
+  //         </button>
+  //       </div>
+  //       <div class="modal-body" id="modal-body">
+  //       </div>
+  //     </div>
+  //   </div>
+  // </div>`;
+  document.querySelector('#modal-container').innerHTML = `<div class="modal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Edit Pin</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="modal-body">
+        <p>Modal body text goes here.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>`;
+};
+
+export default formModal;

--- a/src/javascripts/components/pins.js
+++ b/src/javascripts/components/pins.js
@@ -11,6 +11,7 @@ const showPins = (array) => {
       <h5 class="card-title">${item.pin_title}</h5>
       <p>${item.pin_description}</p>
       <a href="#" class="btn btn-danger" id="deletePin^^${item.firebaseKey}^^${item.board_id}">Delete Pin</a>
+      <a href="#" class="btn btn-danger mt-2" id="edit-pin^^${item.firebaseKey}">Change Pin Board</a>
     </div>
   </div>`;
   });

--- a/src/javascripts/components/pins.js
+++ b/src/javascripts/components/pins.js
@@ -11,7 +11,7 @@ const showPins = (array) => {
       <h5 class="card-title">${item.pin_title}</h5>
       <p>${item.pin_description}</p>
       <a href="#" class="btn btn-danger" id="deletePin^^${item.firebaseKey}^^${item.board_id}">Delete Pin</a>
-      <a href="#" class="btn btn-danger mt-2" id="edit-pin^^${item.firebaseKey}">Change Pin Board</a>
+      <button class="btn btn-danger mt-2" data-toggle="modal" data-target="#formModal" id="edit-pin^^${item.firebaseKey}">Change Pin Board</button>
     </div>
   </div>`;
   });

--- a/src/javascripts/data/pinData.js
+++ b/src/javascripts/data/pinData.js
@@ -12,6 +12,12 @@ const getPins = (firebaseKey) => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
+const getSinglePin = (firebaseKey) => new Promise((resolve, reject) => {
+  axios.get(`${dbUrl}/pins/${firebaseKey}.json`)
+    .then((response) => resolve(response.data))
+    .catch((error) => reject(error));
+});
+
 // Delete Pins
 
 const deletePin = (firebaseKey, boardId) => new Promise((resolve, reject) => {
@@ -32,4 +38,15 @@ const createPin = (pinObject) => new Promise((resolve, reject) => {
         });
     }).catch((error) => reject(error));
 });
-export { getPins, deletePin, createPin };
+
+// Update Pins
+const updatePin = (firebaseKey, pinObject) => new Promise((resolve, reject) => {
+  axios.patch(`${dbUrl}/pins/${firebaseKey}.json`, pinObject)
+    .then(() => getPins(pinObject.board_id))
+    .then((pinsArray) => resolve(pinsArray))
+    .catch((error) => reject(error));
+});
+
+export {
+  getPins, deletePin, createPin, getSinglePin, updatePin
+};

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -7,7 +7,7 @@ import showPins from '../components/pins';
 import { createBoard, getBoards } from '../data/boardData';
 import deleteBoardPins from '../data/pinBoardData';
 import {
-  createPin, deletePin, getPins, // getSinglePin, // updatePin
+  createPin, deletePin, getPins, getSinglePin, updatePin
 } from '../data/pinData';
 
 const domEvents = (userId) => {
@@ -83,22 +83,20 @@ const domEvents = (userId) => {
     // Click event for showing modal on editing pin board
     if (e.target.id.includes('edit-pin')) {
       e.preventDefault();
-      console.warn('yup');
-      // const firebaseKey = e.target.id.split('^^')[1];
-      formModal();
-      editPinForm();
-      // getSinglePin(firebaseKey).then((pinObj) => editPinForm(pinObj));
+      const firebaseKey = e.target.id.split('^^')[1];
+      formModal('Edit Pin');
+      getSinglePin(firebaseKey).then((pinObject) => editPinForm(pinObject, userId));
     }
 
-    // if (e.target.includes('update-pin')) {
-    //   e.preventDefault();
-    //   const firebaseKey = e.target.id.split('^^')[1];
-    //   const pinObj = {
-    //     board_id: document.querySelector('#board').value
-    //   };
-    //   updatePin(firebaseKey, pinObj).then((pinsArray) => showPins(pinsArray));
-    //   $('formModal').modal('toggle');
-    // }
+    if (e.target.id.includes('update-pin')) {
+      e.preventDefault();
+      const firebaseKey = e.target.id.split('^^')[1];
+      const pinObj = {
+        board_id: document.querySelector('#board').value
+      };
+      updatePin(firebaseKey, pinObj).then((pinsArray) => showPins(pinsArray));
+      $('#formModal').modal('toggle');
+    }
   });
 };
 

--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -1,10 +1,14 @@
 import showBoards from '../components/boards';
 import addBoardForm from '../components/forms/addBoardForm';
 import addPinForm from '../components/forms/addPinForm';
+import editPinForm from '../components/forms/editPinForm';
+import formModal from '../components/forms/formModal';
 import showPins from '../components/pins';
 import { createBoard, getBoards } from '../data/boardData';
 import deleteBoardPins from '../data/pinBoardData';
-import { createPin, deletePin, getPins } from '../data/pinData';
+import {
+  createPin, deletePin, getPins, // getSinglePin, // updatePin
+} from '../data/pinData';
 
 const domEvents = (userId) => {
   document.querySelector('body').addEventListener('click', (e) => {
@@ -75,6 +79,26 @@ const domEvents = (userId) => {
       };
       createBoard(boardObj, userId).then((boardArray) => showBoards(boardArray));
     }
+
+    // Click event for showing modal on editing pin board
+    if (e.target.id.includes('edit-pin')) {
+      e.preventDefault();
+      console.warn('yup');
+      // const firebaseKey = e.target.id.split('^^')[1];
+      formModal();
+      editPinForm();
+      // getSinglePin(firebaseKey).then((pinObj) => editPinForm(pinObj));
+    }
+
+    // if (e.target.includes('update-pin')) {
+    //   e.preventDefault();
+    //   const firebaseKey = e.target.id.split('^^')[1];
+    //   const pinObj = {
+    //     board_id: document.querySelector('#board').value
+    //   };
+    //   updatePin(firebaseKey, pinObj).then((pinsArray) => showPins(pinsArray));
+    //   $('formModal').modal('toggle');
+    // }
   });
 };
 


### PR DESCRIPTION
Added Update feature to change a pin's board.

## Description
A user can now click 'Change Board' on a pin and update the board to which it belongs. 

## Related Issue
fixes #24 
fixes #25 
fixes #26 

## Motivation and Context
A user may want to update their personal pins and boards without having to delete the pin, this will allow the user to move pins around and update as needed. 

## How Can This Be Tested?
npm -start. Click on 'Visit Board' on any board. On a pin, click 'Change Board'. Chose a new board from the dropdown. On submit, it will render the board that was chosen along with all pins. 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
