### PR TITLE
Double search event

### DIFF
--- a/src/javascripts/events/domEvents.js
+++ b/src/javascripts/events/domEvents.js
@@ -119,6 +119,7 @@ const domEvents = (userId) => {
     }
     // Search bar
     if (e.target.id.includes('search-btn')) {
+      e.preventDefault();
       const searchValue = document.querySelector('#search-bar').value;
       getSearchPins(userId, searchValue).then((pinsArray) => showPins(pinsArray));
       document.querySelector('#main-container').innerHTML = `<h1>Search Results for ${searchValue}</h1>`;


### PR DESCRIPTION
Search Event was resetting DOM 

## Description
When a user submitted a value in a search bar, the DOM was resetting. 

## Motivation and Context
This bug was rendering the search bar function unusable by resetting the DOM. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
